### PR TITLE
Check app structure and permissions

### DIFF
--- a/env
+++ b/env
@@ -1,1 +1,2 @@
 ADMIN_TELEGRAM_IDS=128787773,7159783954
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/raffle_db

--- a/migrations/0000_foamy_blue_shield.sql
+++ b/migrations/0000_foamy_blue_shield.sql
@@ -1,0 +1,136 @@
+CREATE TABLE "admin_actions" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"admin_id" varchar NOT NULL,
+	"action" text NOT NULL,
+	"target_type" text NOT NULL,
+	"target_id" varchar NOT NULL,
+	"details" jsonb,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "bot_config" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"bot_token" text NOT NULL,
+	"bot_username" text NOT NULL,
+	"start_link" text NOT NULL,
+	"admin_telegram_ids" text[] NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "raffle_participants" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" varchar NOT NULL,
+	"raffle_id" varchar NOT NULL,
+	"joined_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "raffles" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"channel_id" varchar NOT NULL,
+	"message_id" varchar NOT NULL,
+	"forwarded_message_id" varchar,
+	"request_number" integer NOT NULL,
+	"prize_type" text NOT NULL,
+	"prize_value" integer,
+	"required_channels" text[] NOT NULL,
+	"raffle_datetime" timestamp NOT NULL,
+	"level_required" integer DEFAULT 1 NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"submitter_id" varchar NOT NULL,
+	"reviewer_id" varchar,
+	"rejection_reason" text,
+	"participant_count" integer DEFAULT 0 NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"original_data" jsonb,
+	"message_url" text,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "referrals" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"referrer_id" varchar NOT NULL,
+	"referred_id" varchar NOT NULL,
+	"points_earned" integer DEFAULT 50 NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"sid" varchar PRIMARY KEY NOT NULL,
+	"sess" jsonb NOT NULL,
+	"expire" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sponsor_channels" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"channel_id" varchar NOT NULL,
+	"channel_username" varchar,
+	"channel_name" text NOT NULL,
+	"channel_url" text NOT NULL,
+	"description" text,
+	"points_reward" integer DEFAULT 100 NOT NULL,
+	"is_special" boolean DEFAULT false NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"display_order" integer DEFAULT 0 NOT NULL,
+	"bot_has_access" boolean DEFAULT false NOT NULL,
+	"last_access_check" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "sponsor_channels_channel_id_unique" UNIQUE("channel_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_seen_raffles" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" varchar NOT NULL,
+	"raffle_id" varchar NOT NULL,
+	"seen_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "user_sponsor_memberships" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" varchar NOT NULL,
+	"channel_id" varchar NOT NULL,
+	"is_member" boolean DEFAULT false NOT NULL,
+	"points_earned" integer DEFAULT 0 NOT NULL,
+	"joined_at" timestamp,
+	"left_at" timestamp,
+	"last_checked" timestamp DEFAULT now(),
+	"check_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"telegram_id" varchar,
+	"username" text,
+	"first_name" text,
+	"last_name" text,
+	"email" varchar,
+	"profile_image_url" varchar,
+	"auth_method" text DEFAULT 'telegram' NOT NULL,
+	"user_type" text DEFAULT 'regular' NOT NULL,
+	"admin_level" integer DEFAULT 1,
+	"points" integer DEFAULT 0 NOT NULL,
+	"level" integer DEFAULT 1 NOT NULL,
+	"referral_code" varchar,
+	"referrer_id" varchar,
+	"referral_reward" integer DEFAULT 50 NOT NULL,
+	"is_sponsor_member" boolean DEFAULT false NOT NULL,
+	"is_restricted" boolean DEFAULT false NOT NULL,
+	"restriction_start" timestamp,
+	"restriction_end" timestamp,
+	"restriction_reason" text,
+	"submission_count" integer DEFAULT 0 NOT NULL,
+	"last_submission_at" timestamp,
+	"last_login_at" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "users_telegram_id_unique" UNIQUE("telegram_id"),
+	CONSTRAINT "users_email_unique" UNIQUE("email"),
+	CONSTRAINT "users_referral_code_unique" UNIQUE("referral_code")
+);
+--> statement-breakpoint
+CREATE INDEX "IDX_session_expire" ON "sessions" USING btree ("expire");

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,848 @@
+{
+  "id": "c82e3782-2791-47a5-90dc-028fc1bebe35",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_actions": {
+      "name": "admin_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_config": {
+      "name": "bot_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_link": {
+          "name": "start_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_telegram_ids": {
+          "name": "admin_telegram_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raffle_participants": {
+      "name": "raffle_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raffle_id": {
+          "name": "raffle_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raffles": {
+      "name": "raffles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forwarded_message_id": {
+          "name": "forwarded_message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize_type": {
+          "name": "prize_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize_value": {
+          "name": "prize_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_channels": {
+          "name": "required_channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raffle_datetime": {
+          "name": "raffle_datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_required": {
+          "name": "level_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitter_id": {
+          "name": "submitter_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "original_data": {
+          "name": "original_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_url": {
+          "name": "message_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referrals": {
+      "name": "referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referrer_id": {
+          "name": "referrer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referred_id": {
+          "name": "referred_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points_earned": {
+          "name": "points_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sess": {
+          "name": "sess",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expire": {
+          "name": "expire",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_session_expire": {
+          "name": "IDX_session_expire",
+          "columns": [
+            {
+              "expression": "expire",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sponsor_channels": {
+      "name": "sponsor_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_username": {
+          "name": "channel_username",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points_reward": {
+          "name": "points_reward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_special": {
+          "name": "is_special",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bot_has_access": {
+          "name": "bot_has_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_access_check": {
+          "name": "last_access_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sponsor_channels_channel_id_unique": {
+          "name": "sponsor_channels_channel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_seen_raffles": {
+      "name": "user_seen_raffles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raffle_id": {
+          "name": "raffle_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sponsor_memberships": {
+      "name": "user_sponsor_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_member": {
+          "name": "is_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "points_earned": {
+          "name": "points_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "check_count": {
+          "name": "check_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telegram'"
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "admin_level": {
+          "name": "admin_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_id": {
+          "name": "referrer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_reward": {
+          "name": "referral_reward",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "is_sponsor_member": {
+          "name": "is_sponsor_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_restricted": {
+          "name": "is_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "restriction_start": {
+          "name": "restriction_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_end": {
+          "name": "restriction_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_reason": {
+          "name": "restriction_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submission_at": {
+          "name": "last_submission_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_telegram_id_unique": {
+          "name": "users_telegram_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "telegram_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_referral_code_unique": {
+          "name": "users_referral_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "referral_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1756140849446,
+      "tag": "0000_foamy_blue_shield",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -117,8 +117,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const pendingRejectedRaffles = [...allPending, ...allRejected];
         const duplicatePendingRejected = pendingRejectedRaffles.find(r => r.originalData?.messageUrl === payload.messageUrl);
         
-        // Check approved raffles (based on final URL - messageLink field)
-        const duplicateApproved = allApproved.find(r => r.messageLink === payload.messageUrl);
+        // Check approved raffles (based on final URL - messageUrl field)
+        const duplicateApproved = allApproved.find(r => r.messageUrl === payload.messageUrl);
         
         const duplicate = duplicatePendingRejected || duplicateApproved;
         
@@ -224,7 +224,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Admin route for approving raffles with level assignment
   app.patch("/api/raffles/:id/approve", async (req, res) => {
     try {
-      const { levelRequired, adminUserId, status } = req.body;
+      const { levelRequired, adminUserId, status, messageUrl } = req.body;
       
       // Check if user is bot admin
       const admin = await storage.getUser(adminUserId);
@@ -232,7 +232,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "Access denied" });
       }
       
-      const raffle = await storage.approveRaffleWithLevel(req.params.id, levelRequired, adminUserId);
+      const raffle = await storage.approveRaffleWithLevel(req.params.id, levelRequired, adminUserId, messageUrl);
       if (!raffle) {
         return res.status(404).json({ message: "Raffle not found" });
       }
@@ -244,7 +244,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.patch("/api/raffles/:id/reject", async (req, res) => {
     try {
-      const { adminUserId, reason, restriction } = req.body;
+      const { adminUserId, reason, restriction, messageUrl } = req.body;
       
       // Check if user is bot admin
       const admin = await storage.getUser(adminUserId);
@@ -252,7 +252,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "Access denied" });
       }
       
-      const raffle = await storage.rejectRaffle(req.params.id, reason, restriction || { type: "none" }, adminUserId);
+      const raffle = await storage.rejectRaffle(req.params.id, reason, restriction || { type: "none" }, adminUserId, messageUrl);
       if (!raffle) {
         return res.status(404).json({ message: "Raffle not found" });
       }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -45,8 +45,8 @@ export interface IStorage {
   createRaffle(raffle: InsertRaffle): Promise<Raffle>;
   updateRaffle(id: string, updates: Partial<Raffle>): Promise<Raffle | undefined>;
   getRafflesBySubmitter(submitterId: string): Promise<Raffle[]>;
-  approveRaffleWithLevel(id: string, levelRequired: number, adminUserId: string): Promise<Raffle | undefined>;
-  rejectRaffle(id: string, reason: string, restriction: any, adminUserId: string): Promise<Raffle | undefined>;
+  approveRaffleWithLevel(id: string, levelRequired: number, adminUserId: string, messageUrl?: string): Promise<Raffle | undefined>;
+  rejectRaffle(id: string, reason: string, restriction: any, adminUserId: string, messageUrl?: string): Promise<Raffle | undefined>;
   getTodaysRaffles(userLevel: number): Promise<Raffle[]>;
   getEndedRaffles(userLevel: number): Promise<Raffle[]>;
   deleteRaffle(id: string): Promise<boolean>;
@@ -311,20 +311,26 @@ export class DatabaseStorage implements IStorage {
     return await this.updateUser(userId, { level: newLevel });
   }
 
-  async approveRaffleWithLevel(id: string, levelRequired: number, adminUserId: string): Promise<Raffle | undefined> {
+  async approveRaffleWithLevel(id: string, levelRequired: number, adminUserId: string, messageUrl?: string): Promise<Raffle | undefined> {
     return await this.updateRaffle(id, { 
       status: "approved" as any, 
       levelRequired,
-      reviewerId: adminUserId
+      reviewerId: adminUserId,
+      messageUrl: messageUrl // لینک نهایی تایید شده توسط مدیر
     });
   }
 
-  async rejectRaffle(id: string, reason: string, restriction: any, adminUserId: string): Promise<Raffle | undefined> {
+  async rejectRaffle(id: string, reason: string, restriction: any, adminUserId: string, messageUrl?: string): Promise<Raffle | undefined> {
     const updates: any = { 
       status: "rejected" as any, 
       rejectionReason: reason,
       reviewerId: adminUserId
     };
+
+    // اگر messageUrl ارسال شده باشد، آن را ذخیره کنیم
+    if (messageUrl) {
+      updates.messageUrl = messageUrl;
+    }
 
     // Handle user restriction if specified
     if (restriction.type !== "none") {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -95,6 +95,7 @@ export const raffles = pgTable("raffles", {
   participantCount: integer("participant_count").notNull().default(0),
   version: integer("version").notNull().default(1), // Version tracking for edits
   originalData: jsonb("original_data"), // Store original submission for version history
+  messageUrl: text("message_url"), // لینک نهایی تایید شده توسط مدیر
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });


### PR DESCRIPTION
Add `messageUrl` field and update raffle approval/rejection and duplicate detection to correctly store and use the final message link.

Previously, the system failed to persist the final message link (potentially edited by an admin) when a raffle was approved or rejected. This caused issues with duplicate link detection for approved raffles, as the logic relied on a non-existent field. This PR introduces a dedicated `messageUrl` field in the database, updates the client and server to correctly send and store this final link, and modifies the duplicate check to use this new, reliable source.

---
<a href="https://cursor.com/background-agent?bcId=bc-39d1f2ff-ab9c-49ba-8983-0824d8ce2292">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39d1f2ff-ab9c-49ba-8983-0824d8ce2292">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

